### PR TITLE
Removed justify-center to avoid text width skewing alignment

### DIFF
--- a/src/components/quickLinks/quickLinks.ce.vue
+++ b/src/components/quickLinks/quickLinks.ce.vue
@@ -57,7 +57,7 @@ export default {
       v-for="(link, index) in LinksList"
       :key="index"
       :href="link.href"
-      class="group flex min-h-24 justify-center py-2"
+      class="group flex min-h-24 py-2"
     >
       <div
         :class="`flex h-14 w-14 flex-shrink-0 items-center justify-center bg-mustard group-hover:bg-primary-pink ${link.SVGPadding ?? 'p-2'} `"


### PR DESCRIPTION
### Description

Justify-center was causing a wonky alignment when text wasn't long enough. Removing it doesn't effect the other quick link items but does remove this issue.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
