### PR TITLE
add back in group pages

### DIFF
--- a/src/components/group-page/group-page.ce.vue
+++ b/src/components/group-page/group-page.ce.vue
@@ -23,6 +23,10 @@
             url="/adopt-an-activity"
           />
           <InterestButton v-if="!isAdoptable" :activity-id="groupId" />
+        </div>
+        <div
+          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row sm:hidden"
+        >
           <GroupPagesList
             :group-id="groupId"
             :group-url="pageActivity.url_name"

--- a/src/components/group-page/group-page.ce.vue
+++ b/src/components/group-page/group-page.ce.vue
@@ -23,31 +23,15 @@
             url="/adopt-an-activity"
           />
           <InterestButton v-if="!isAdoptable" :activity-id="groupId" />
-        </div>
-        <div
-          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row sm:hidden"
-        >
           <GroupPagesList
             :group-id="groupId"
             :group-url="pageActivity.url_name"
+            :selected-url="pageDetails.url_title"
           />
         </div>
-        <div v-if="pageActivity.description" class="flex flex-col">
-          <h2 class="mb-5 text-3xl font-bold">About</h2>
-          <article v-html="pageActivity.description"></article>
-        </div>
-        <div v-else class="flex flex-col gap-y-6">
-          <div class="flex flex-col">
-            <h3 class="text-xl font-semibold">Meeting times</h3>
-            <p>Please get in touch via email to find out our meeting times.</p>
-          </div>
-          <div class="flex flex-col">
-            <h3 class="text-xl font-semibold">Get Involved</h3>
-            <p>
-              We are open to all students, and encourage those from all
-              backgrounds to come along!
-            </p>
-          </div>
+        <div class="flex flex-col">
+          <h1 class="text-3xl font-bold">{{ pageDetails.title }}</h1>
+          <article v-html="groupPage.content"></article>
         </div>
       </div>
       <div class="flex flex-col gap-y-8">
@@ -72,6 +56,7 @@
           <GroupPagesList
             :group-id="groupId"
             :group-url="pageActivity.url_name"
+            :selected-url="pageDetails.url_title"
           />
         </div>
         <div class="flex flex-col">
@@ -90,22 +75,10 @@
         </div>
       </div>
     </div>
-    <div class="flex flex-col">
-      <Events :groupid="groupId" title="Events" icon />
-      <Shop :selectedgroup="groupId" hidefilter icon title="Products" />
-      <Activities
-        v-if="subgroupCategoryId"
-        :selectedcategory="subgroupCategoryId"
-        :title="subgroupCategoryName"
-      />
-    </div>
   </main>
 </template>
 <script>
 import Button from "../../components/button/button.ce.vue";
-import Events from "../../components/Events/events.ce.vue";
-import Shop from "../../components/shop/shop-index/shop.ce.vue";
-import Activities from "../../components/activities/activities.ce.vue";
 import ActivitiesContacts from "../../components/ActivitiesContacts/activitiescontacts.ce.vue";
 import axios from "../../_common/axios.mjs";
 import InterestButton from "../interest-button/interest-button.ce.vue";
@@ -113,10 +86,13 @@ import GroupPagesList from "../group-pages-list/group-pages-list.ce.vue";
 export default {
   props: {
     groupId: { type: String, default: null },
+    pageUrl: { type: String, default: null },
   },
   data() {
     return {
       pageActivity: {},
+      groupPage: {},
+      pageDetails: {},
       subgroupCategoryId: null,
       subgroupCategoryName: null,
       isAdoptable: false,
@@ -127,9 +103,6 @@ export default {
   components: {
     Button,
     ActivitiesContacts,
-    Events,
-    Shop,
-    Activities,
     InterestButton,
     GroupPagesList,
   },
@@ -148,10 +121,23 @@ export default {
             "X-Site-Id": self.siteid,
           },
         }),
+        axios.get(
+          "https://pluto.sums.su/api/groups/" +
+            self.groupId +
+            "/pages/" +
+            self.pageUrl,
+          {
+            headers: {
+              "X-Site-Id": self.siteid,
+            },
+          },
+        ),
       ])
       .then(
-        axios.spread((response1, response2) => {
+        axios.spread((response1, response2, response3) => {
           self.pageActivity = response1.data;
+          self.groupPage = response3.data;
+          self.pageDetails = response3.data.page;
           self.loading = false;
           self.pageActivity.category = response2.data.find(
             (item) => item.id === self.pageActivity.activity_category_id,

--- a/src/components/group-page/group-page.ce.vue
+++ b/src/components/group-page/group-page.ce.vue
@@ -1,9 +1,9 @@
 <template>
   <main>
-    <div class="flex flex-col gap-x-20 gap-y-12 sm:flex-row">
+    <div class="flex flex-col gap-x-20 gap-y-12 md:flex-row">
       <div class="flex flex-grow flex-col gap-y-6">
         <div
-          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row sm:hidden"
+          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row md:hidden"
         >
           <!-- {if category_name != "College Sport (Groups)"} -->
           <Button
@@ -25,7 +25,7 @@
           <InterestButton v-if="!isAdoptable" :activity-id="groupId" />
         </div>
         <div
-          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row sm:hidden"
+          class="flex flex-col gap-x-4 gap-y-4 xxs:w-max xxs:flex-row md:hidden"
         >
           <GroupPagesList
             :group-id="groupId"
@@ -39,7 +39,7 @@
         </div>
       </div>
       <div class="flex flex-col gap-y-8">
-        <div class="hidden w-max flex-col gap-y-4 sm:flex">
+        <div class="hidden w-max flex-col gap-y-4 md:flex">
           <Button
             v-if="isActivity"
             :class="{ 'bg-light-blue': title == 'join' }"

--- a/src/components/group-page/group-page.component.js
+++ b/src/components/group-page/group-page.component.js
@@ -1,0 +1,4 @@
+import { register } from "../../_common/registerComponent";
+import GroupPage from "./group-page.ce.vue";
+
+register("group-page", GroupPage);

--- a/src/components/group-page/group-page.stories.js
+++ b/src/components/group-page/group-page.stories.js
@@ -5,4 +5,14 @@ export default {
   component: "group-page",
 };
 
-export const Default = {};
+export const Default = {
+  args: {
+    groupId: 483,
+    pageUrl: "society-pages",
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};

--- a/src/components/group-page/group-page.stories.js
+++ b/src/components/group-page/group-page.stories.js
@@ -1,0 +1,8 @@
+import "./group-page.component.js";
+
+export default {
+  title: "Components/Group Page",
+  component: "group-page",
+};
+
+export const Default = {};

--- a/src/components/group-page/group-page.stories.js
+++ b/src/components/group-page/group-page.stories.js
@@ -1,7 +1,7 @@
 import "./group-page.component.js";
 
 export default {
-  title: "Components/Group Page",
+  title: "Components/Activities/Group Page",
   component: "group-page",
 };
 

--- a/src/components/group-pages-list/group-pages-list.ce.vue
+++ b/src/components/group-pages-list/group-pages-list.ce.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="flex w-full flex-col">
+    <h2 class="text-2xl font-bold" v-if="pages[0]">Group Pages</h2>
+    <div class="flex w-full flex-col gap-4">
+      <Button
+        v-for="page in pages"
+        :key="page.id"
+        :title="page.title"
+        class="btn-student-life w-full px-10 text-center"
+        :class="{ 'btn-student-life-active': page.url_title == selectedUrl }"
+        :url="'/activities/page/' + page.activity_id + '/' + page.url_title"
+      />
+    </div>
+  </div>
+</template>
+<script>
+import axios from "../../_common/axios.mjs";
+import Button from "../button/button.ce.vue";
+export default {
+  name: "GroupPagesList",
+  props: {
+    groupId: { type: String, default: null },
+    groupUrl: { type: String, default: "" },
+    selectedUrl: { type: String, default: "" },
+  },
+  components: {
+    Button,
+  },
+  data() {
+    return {
+      pages: {},
+    };
+  },
+  created() {
+    var self = this;
+    axios
+      .get(
+        "https://pluto.sums.su/api/groups/" + self.groupId + "/pages?all=1",
+        {
+          headers: {
+            "X-Site-Id": self.siteid,
+          },
+        },
+      )
+      .then((response) => {
+        self.pages = response.data;
+        console.log(self.pages);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  },
+};
+</script>

--- a/src/components/group-pages-list/group-pages-list.ce.vue
+++ b/src/components/group-pages-list/group-pages-list.ce.vue
@@ -44,7 +44,6 @@ export default {
       )
       .then((response) => {
         self.pages = response.data;
-        console.log(self.pages);
       })
       .catch((error) => {
         console.log(error);

--- a/src/components/group-pages-list/group-pages-list.component.js
+++ b/src/components/group-pages-list/group-pages-list.component.js
@@ -1,0 +1,4 @@
+import { register } from "../../_common/registerComponent";
+import GroupPagesList from "./group-pages-list.ce.vue";
+
+register("group-pages-list", GroupPagesList);

--- a/src/components/group-pages-list/group-pages-list.stories.js
+++ b/src/components/group-pages-list/group-pages-list.stories.js
@@ -1,8 +1,18 @@
 import "./group-pages-list.component.js";
 
 export default {
-  title: "Components/Group Pages List",
+  title: "Components/Activities/Group Pages List",
   component: "group-pages-list",
 };
 
-export const Default = {};
+export const Default = {
+  args: {
+    groupId: 483,
+    pageUrl: "society-pages",
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};

--- a/src/components/group-pages-list/group-pages-list.stories.js
+++ b/src/components/group-pages-list/group-pages-list.stories.js
@@ -1,0 +1,8 @@
+import "./group-pages-list.component.js";
+
+export default {
+  title: "Components/Group Pages List",
+  component: "group-pages-list",
+};
+
+export const Default = {};

--- a/src/pages/student-life/activities-page/activities-page.ce.vue
+++ b/src/pages/student-life/activities-page/activities-page.ce.vue
@@ -1,0 +1,97 @@
+<template>
+  <ActivitiesHeroBanner
+    v-if="loading"
+    :group="Activity.name"
+    :id="Activity.id"
+    image="https://assets-cdn.sums.su/YU/website/img/Banners/1500x400_Web_Banners_General.jpg"
+    :logo="Activity.thumbnail_url"
+    :category="Activity.category"
+  />
+  <ActivitiesHeroBanner
+    v-if="!loading"
+    :group="Activity.name"
+    :id="Activity.id"
+    image="https://assets-cdn.sums.su/YU/website/img/Banners/1500x400_Web_Banners_General.jpg"
+    :logo="Activity.thumbnail_url"
+    :category="Activity.category"
+    :constitution="constitution"
+  />
+  <ActivityBreadcrumb
+    v-if="!loading"
+    :category-name="Activity.category"
+    :category-id="Activity.activity_category_id"
+    :group-name="Activity.name"
+    :group-url="Activity.url_name"
+  />
+  <div class="container mx-auto">
+    <GroupPage :group-id="activityid" :page-url="pageurl" />
+  </div>
+</template>
+<script>
+import ActivitiesHeroBanner from "../../../components/ActivitiesHeroBanner/activitiesherobanner.ce.vue";
+import ActivityBreadcrumb from "../../../components/activity-breadcrumb/activity-breadcrumb.ce.vue";
+import GroupPage from "../../../components/group-page/group-page.ce.vue";
+import axios from "../../../_common/axios.mjs";
+export default {
+  props: {
+    activityid: {
+      type: Number,
+      default: null,
+    },
+    siteid: {
+      type: String,
+      default: null,
+    },
+    pageurl: {
+      type: String,
+      default: null,
+    },
+    constitution: {
+      type: String,
+      default: null,
+    },
+  },
+  components: {
+    ActivitiesHeroBanner,
+    ActivityBreadcrumb,
+    GroupPage,
+  },
+  data() {
+    return {
+      Activity: {},
+      loading: true,
+    };
+  },
+  created() {
+    var self = this;
+    self.loading = true;
+    axios
+      .all([
+        axios.get("https://pluto.sums.su/api/groups/" + self.activityid, {
+          headers: {
+            "X-Site-Id": self.siteid,
+          },
+        }),
+        axios.get("https://pluto.sums.su/api/groups/categories", {
+          headers: {
+            "X-Site-Id": self.siteid,
+          },
+        }),
+      ])
+      .then(
+        axios.spread((response1, response2) => {
+          self.Activity = response1.data;
+          self.Activity.category = response2.data.find(
+            (item) => item.id === self.Activity.activity_category_id,
+          ).name;
+          self.loading = false;
+        }),
+      );
+  },
+  methods: {
+    wrapURL(URL) {
+      return "'" + URL + "'";
+    },
+  },
+};
+</script>

--- a/src/pages/student-life/activities-page/activities-page.component.js
+++ b/src/pages/student-life/activities-page/activities-page.component.js
@@ -1,0 +1,4 @@
+import { register } from "../../../_common/registerComponent";
+import ActivitiesPage from "./activities-page.ce.vue";
+
+register("activities-page", ActivitiesPage);

--- a/src/pages/student-life/activities-page/activities-page.stories.js
+++ b/src/pages/student-life/activities-page/activities-page.stories.js
@@ -1,0 +1,18 @@
+import "./activities-page.component.js";
+
+export default {
+  title: "Pages/Activities Page",
+  component: "activities-page",
+};
+
+export const Default = {
+  args: {
+    activityid: 483,
+    pageurl: "society-pages",
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};

--- a/src/pages/student-life/activities-page/activities-page.stories.js
+++ b/src/pages/student-life/activities-page/activities-page.stories.js
@@ -1,7 +1,7 @@
 import "./activities-page.component.js";
 
 export default {
-  title: "Pages/Activities Page",
+  title: "Pages/Student Life/Activities Page",
   component: "activities-page",
 };
 

--- a/src/pages/student-life/activities-view/activities-view.stories.js
+++ b/src/pages/student-life/activities-view/activities-view.stories.js
@@ -1,13 +1,24 @@
 import "./activities-view.component.js";
 
 export default {
-  title: "Pages/Student Life/ActivitiesView",
+  title: "Pages/Student Life/Activities View",
   component: "activities-view",
 };
 
 export const cybersoc = {
   args: {
     activityid: 7,
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};
+
+export const TestSoc = {
+  args: {
+    activityid: 483,
   },
   parameters: {
     a11y: {


### PR DESCRIPTION
### Description
This adds back the ability for groups to have their own pages, and allows them to embed anything they like to their own page. Closes #293 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
