### PR TITLE
update to be yorksu.org and target blank

### DIFF
--- a/src/components/Navbar/navbar.ce.vue
+++ b/src/components/Navbar/navbar.ce.vue
@@ -169,9 +169,12 @@
                 :key="subheading.name"
                 :class="`${index != section.links.length - 1 && 'border-b border-black pb-3'} ${index != 0 && 'pt-3'}`"
               >
-                <a :href="subheading.link" class="hover:underline">{{
-                  subheading.name
-                }}</a>
+                <a
+                  :href="subheading.link"
+                  class="hover:underline"
+                  :target="subheading.target ?? '_self'"
+                  >{{ subheading.name }}</a
+                >
               </li>
             </ul>
           </div>
@@ -192,9 +195,12 @@
                     v-for="subheading in section.links"
                     :key="subheading.name"
                   >
-                    <a :href="subheading.link" class="hover:underline">{{
-                      subheading.name
-                    }}</a>
+                    <a
+                      :href="subheading.link"
+                      class="hover:underline"
+                      :target="subheading.target ?? '_self'"
+                      >{{ subheading.name }}</a
+                    >
                   </li>
                 </ul>
               </div>
@@ -444,7 +450,8 @@ export default {
             links: [
               {
                 name: "Student Group Resource Hub",
-                link: "https://resource-hub.yusu.org",
+                link: "https://resource-hub.yorksu.org",
+                target: "_blank",
               },
               {
                 name: "Book an Event",
@@ -493,6 +500,7 @@ export default {
               {
                 name: "Jobs",
                 link: "https://apply.yorksu.org",
+                target: "_blank",
               },
               {
                 name: "Contact Us",


### PR DESCRIPTION
### Description
Updates to be target blank and resource hub to be yorksu.org closes #313 

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
