### PR TITLE
Default banner prop can handle string

### DIFF
--- a/src/components/Carousel/carousel.ce.vue
+++ b/src/components/Carousel/carousel.ce.vue
@@ -67,7 +67,7 @@ export default {
       default: 5000,
     },
     defaultBanner: {
-      type: Object,
+      type: [Object, String],
       default() {
         return {
           url: "/",
@@ -87,7 +87,11 @@ export default {
     };
   },
   async created() {
-    this.banners.push(this.defaultBanner);
+    let banner = this.defaultBanner;
+    if (typeof banner === "string") {
+      banner = JSON.parse(banner);
+    }
+    this.banners.push(banner);
     this.getBanners();
   },
   async mounted() {

--- a/src/components/Carousel/carousel.stories.js
+++ b/src/components/Carousel/carousel.stories.js
@@ -7,3 +7,10 @@ export default {
 };
 
 export const Default = {};
+
+export const DefaultBannerProp = {
+  args: {
+    defaultBanner:
+      '{"url": "https://yorksu.org/elections","img": "https://d7c4643dcbda7415a35e-80960cc71f8ebfe47418d0eb60e429bc.ssl.cf3.rackcdn.com/bnr_bwvys3_favlw9_1900x400_hero_banner_lysu_2_(1).jpg","alt": "Sabbatical Officer Elections"}',
+  },
+};


### PR DESCRIPTION
### Description

This pull request includes changes to the `Carousel` component to enhance its flexibility and improve its functionality. The most important changes include modifying the `defaultBanner` prop to accept either an object or a string, and updating the `created` lifecycle hook to handle the new prop type. Additionally, a new story has been added to demonstrate the `defaultBanner` prop.

Enhancements to `Carousel` component:

* [`src/components/Carousel/carousel.ce.vue`](diffhunk://#diff-ee44ff57004794fcb124a5d6d0fb9b2c61385457344be33d7004a7c51361d895L70-R70): Modified the `defaultBanner` prop to accept both `Object` and `String` types.
* [`src/components/Carousel/carousel.ce.vue`](diffhunk://#diff-ee44ff57004794fcb124a5d6d0fb9b2c61385457344be33d7004a7c51361d895L90-R94): Updated the `created` lifecycle hook to parse the `defaultBanner` prop if it is a string before pushing it to the `banners` array.

Storybook updates:

* [`src/components/Carousel/carousel.stories.js`](diffhunk://#diff-ce5a7e34be7a1951d0d59ff9f02ae364d2dab6a3edfa84f355061dcdc28be7d0R10-R16): Added a new story `DefaultBannerProp` to demonstrate the usage of the `defaultBanner` prop with a string value.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
