### PR TITLE
Added height and width for Safari

### DIFF
--- a/src/components/quickLinks/quickLinks.ce.vue
+++ b/src/components/quickLinks/quickLinks.ce.vue
@@ -38,7 +38,7 @@ export default {
         {
           title: "Check out the 2025 Officer Elections",
           href: "/elections",
-          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M96 80c0-26.5 21.5-48 48-48l288 0c26.5 0 48 21.5 48 48l0 304L96 384 96 80zm313 47c-9.4-9.4-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L409 161c9.4-9.4 9.4-24.6 0-33.9zM0 336c0-26.5 21.5-48 48-48l16 0 0 128 448 0 0-128 16 0c26.5 0 48 21.5 48 48l0 96c0 26.5-21.5 48-48 48L48 480c-26.5 0-48-21.5-48-48l0-96z"/></svg>',
+          icon: '<svg height=100% width=100% xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M96 80c0-26.5 21.5-48 48-48l288 0c26.5 0 48 21.5 48 48l0 304L96 384 96 80zm313 47c-9.4-9.4-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L409 161c9.4-9.4 9.4-24.6 0-33.9zM0 336c0-26.5 21.5-48 48-48l16 0 0 128 448 0 0-128 16 0c26.5 0 48 21.5 48 48l0 96c0 26.5-21.5 48-48 48L48 480c-26.5 0-48-21.5-48-48l0-96z"/></svg>',
           SVGPadding: "p-1.5",
         },
         {


### PR DESCRIPTION
### Description

This pull request includes a small change to the `src/components/quickLinks/quickLinks.ce.vue` file. The change updates the `icon` property of the "Check out the 2025 Officer Elections" link to ensure the SVG scales correctly by setting both the height and width to 100%.

* [`src/components/quickLinks/quickLinks.ce.vue`](diffhunk://#diff-30f99645f6bf3b7362777dbeb6252b170fd941a6dbe60e9a309048d4f9c43ae2L41-R41): Updated the `icon` property to set the height and width attributes to 100% for proper scaling.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
