### PR TITLE
Document Pronouns fix on voter and candidate page

### DIFF
--- a/src/components/elections-candidate/elections-candidate.ce.vue
+++ b/src/components/elections-candidate/elections-candidate.ce.vue
@@ -39,7 +39,7 @@
                 {{ candidate.name }}
               </h3>
               <h4
-                v-if="candidate.pronouns !== '{document_pronouns}'"
+                v-if="!candidate.pronouns.includes('{document_pronouns}')"
                 class="text-xl"
               >
                 {{ candidate.pronouns }}

--- a/src/components/elections-vote/elections-vote.ce.vue
+++ b/src/components/elections-vote/elections-vote.ce.vue
@@ -90,7 +90,7 @@
               class="flex flex-grow flex-col justify-between sm:flex-row"
             >
               <p
-                v-if="candidate.pronouns !== '{document_pronouns}'"
+                v-if="!candidate.pronouns.includes('{document_pronouns}')"
                 class="truncate xs:text-wrap"
               >
                 {{ candidate.pronouns }}

--- a/src/components/elections-vote/elections-vote.ce.vue
+++ b/src/components/elections-vote/elections-vote.ce.vue
@@ -89,7 +89,10 @@
               v-if="candidate.id != 9"
               class="flex flex-grow flex-col justify-between sm:flex-row"
             >
-              <p v-if="candidate.pronouns" class="truncate xs:text-wrap">
+              <p
+                v-if="candidate.pronouns !== '{document_pronouns}'"
+                class="truncate xs:text-wrap"
+              >
                 {{ candidate.pronouns }}
               </p>
               <div class="flex flex-grow items-end justify-end">


### PR DESCRIPTION
### Description

This pull request includes changes to the `elections-candidate` and `elections-vote` components to improve how candidate pronouns are handled. The most important changes include updating conditional checks for pronouns to use the `includes` method.

Improvements to pronoun handling:

* [`src/components/elections-candidate/elections-candidate.ce.vue`](diffhunk://#diff-da590f1f3eb8b30cd991ab8b37271b8a9aec98392d4b817b7d3a01c706b5d21aL42-R42): Modified the conditional check for pronouns to use `!candidate.pronouns.includes('{document_pronouns}')` instead of `candidate.pronouns !== '{document_pronouns}'`.
* [`src/components/elections-vote/elections-vote.ce.vue`](diffhunk://#diff-5c4ddb3679dc8a0c4300be2fcc731ff3d9bf49a62f0d0ed839cd734bbb493d55L92-R95): Updated the conditional check for pronouns to use `!candidate.pronouns.includes('{document_pronouns}')` instead of `candidate.pronouns`.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
