### PR TITLE
Added Badges feature to student pages

### DIFF
--- a/src/components/activity-page/activity-page.ce.vue
+++ b/src/components/activity-page/activity-page.ce.vue
@@ -11,7 +11,7 @@
             :class="{ 'bg-light-blue': title == 'join' }"
             title="Join"
             is-student-life
-            class="xxs:w-min w-full px-10 text-center"
+            class="xxs:w-min w-full px-4 text-center"
             :url="'/shop?activity_id=' + pageActivity.id"
           />
           <Button
@@ -19,7 +19,7 @@
             :class="{ 'bg-light-blue': title == 'join' }"
             title="How to Adopt"
             is-student-life
-            class="px-10 text-center"
+            class="px-4 text-center"
             url="/adopt-an-activity"
           />
           <InterestButton v-if="!isAdoptable" :activity-id="groupId" />
@@ -34,7 +34,10 @@
         </div>
         <div v-if="pageActivity.description" class="flex flex-col">
           <h2 class="mb-5 text-3xl font-bold">About</h2>
-          <article v-html="pageActivity.description"></article>
+          <article
+            class="wrap-anywhere"
+            v-html="pageActivity.description"
+          ></article>
         </div>
         <div v-else class="flex flex-col gap-y-6">
           <div class="flex flex-col">
@@ -50,14 +53,14 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-col gap-y-8">
+      <div class="flex min-w-2/10 flex-col gap-y-8 sm:w-min">
         <div class="hidden w-max flex-col gap-y-4 sm:flex">
           <Button
             v-if="isActivity"
             :class="{ 'bg-light-blue': title == 'join' }"
             title="Join"
             is-student-life
-            class="w-full px-10 text-center"
+            class="w-full px-4 text-center"
             :url="'/shop?activity_id=' + pageActivity.id"
           />
           <Button
@@ -65,14 +68,16 @@
             :class="{ 'bg-light-blue': title == 'join' }"
             title="How to Adopt"
             is-student-life
-            class="w-full px-10 text-center"
+            class="w-full px-4 text-center"
             url="/adopt-an-activity"
           />
           <InterestButton :activity-id="groupId" />
-          <GroupPagesList
-            :group-id="groupId"
-            :group-url="pageActivity.url_name"
-          />
+          <div class="flex flex-col gap-y-4 pt-4">
+            <GroupPagesList
+              :group-id="groupId"
+              :group-url="pageActivity.url_name"
+            />
+          </div>
         </div>
         <div class="flex flex-col">
           <h2 class="mb-5 text-3xl font-bold">Contact</h2>
@@ -87,6 +92,19 @@
             :discord="pageActivity.discord"
             :tiktok="pageActivity.tiktok"
           />
+        </div>
+        <div v-if="badges.length > 0" class="flex flex-col">
+          <h2 class="mb-5 text-3xl font-bold">Badges</h2>
+          <div class="xxs:grid-cols-3 grid grid-cols-2 gap-4 sm:grid-cols-2">
+            <div v-for="(badge, index) in badges" :key="index" class="">
+              <img
+                :src="badge.image_link"
+                :alt="badge.badge_name"
+                :title="badge.badge_name"
+                class="w-full"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -122,6 +140,7 @@ export default {
       isAdoptable: false,
       isAcademicRep: false,
       isActivity: true,
+      badges: [],
     };
   },
   components: {
@@ -148,9 +167,14 @@ export default {
             "X-Site-Id": self.siteid,
           },
         }),
+        axios.get("https://yorksu.org/activities/badges-api/" + self.groupId, {
+          headers: {
+            "X-Site-Id": self.siteid,
+          },
+        }),
       ])
       .then(
-        axios.spread((response1, response2) => {
+        axios.spread((response1, response2, response3) => {
           self.pageActivity = response1.data;
           self.loading = false;
           self.pageActivity.category = response2.data.find(
@@ -161,6 +185,9 @@ export default {
             this.pageActivity.activity_category_id,
           );
           this.isActivity = !this.isAdoptable && !this.isAcademicRep;
+          self.badges = JSON.parse(
+            response3.data.replace(/,\]/g, "]"), // Remove trailing commas before parsing
+          );
         }),
       );
     this.getSubgroupCategoryId();

--- a/src/components/activity-page/activity-page.stories.js
+++ b/src/components/activity-page/activity-page.stories.js
@@ -37,3 +37,14 @@ export const animalCrossing = {
     },
   },
 };
+
+export const testSoc = {
+  args: {
+    groupId: "483",
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};

--- a/src/components/group-pages-list/group-pages-list.ce.vue
+++ b/src/components/group-pages-list/group-pages-list.ce.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="flex w-full flex-col">
-    <h2 class="text-2xl font-bold" v-if="pages[0]">Group Pages</h2>
+    <h2 class="pb-4 text-2xl font-bold" v-if="pages[0]">Group Pages</h2>
     <div class="flex w-full flex-col gap-4">
       <Button
         v-for="page in pages"
         :key="page.id"
         :title="page.title"
-        class="btn-student-life w-full px-10 text-center"
+        class="btn-student-life w-full px-4 text-center"
         :class="{ 'btn-student-life-active': page.url_title == selectedUrl }"
         :url="'/activities/page/' + page.activity_id + '/' + page.url_title"
       />

--- a/src/pages/student-life/activities-view/activities-view.stories.js
+++ b/src/pages/student-life/activities-view/activities-view.stories.js
@@ -98,3 +98,14 @@ export const SwapShop = {
     activityid: 382,
   },
 };
+
+export const cosplaySoc = {
+  args: {
+    activityid: 549,
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};


### PR DESCRIPTION
### Description

This pull request enhances the activity page by improving the display of group pages and badges, refining button styling, and adding new Storybook stories for testing. The main changes focus on UI consistency, introducing a badges section, and supporting better test coverage for user-submitted content.

**UI and Display Improvements:**

* Reduced horizontal padding on activity-related buttons for a more compact and consistent appearance in `activity-page.ce.vue` and `group-pages-list.ce.vue`. [[1]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623L14-R22) [[2]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623L53-R81) [[3]](diffhunk://#diff-db2c4e1011486b12542ee2c6be07a4b99c78d0ae7491ab61a6f615491ce62bcbL3-R9)
* Added a `wrap-anywhere` class to the activity description to improve readability of long content.

**New Features:**

* Introduced a "Badges" section to the activity page, including API integration to fetch and display badges for each activity. [[1]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R96-R108) [[2]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R143) [[3]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R170-R177) [[4]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R188-R190)

**Testing and Storybook Support:**

* Added new Storybook stories (`testSoc` and `cosplaySoc`) for activities, with accessibility checks disabled to accommodate user-submitted content. [[1]](diffhunk://#diff-b740e4f5a62f9e806ee89ef87dfdad1cb32606e2e3404761cc0efaab038836a2R40-R50) [[2]](diffhunk://#diff-07a6507b08a8cb9cafa27aa438a44d4f7eaad4579e98e560c4f6d71a8d8bfec0R101-R111)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
