### PR TITLE
Updated activity view pages for Kato and Lister Split

### DIFF
--- a/src/components/activity-breadcrumb/activity-breadcrumb.ce.vue
+++ b/src/components/activity-breadcrumb/activity-breadcrumb.ce.vue
@@ -92,7 +92,8 @@ export default {
         this.categoryName == "Goodricke College Sports" ||
         this.categoryName == "Halifax College Sports" ||
         this.categoryName == "Langwith College Sports" ||
-        this.categoryName == "Anne Lister & David Kato College Sports" ||
+        this.categoryName == "Anne Lister College Sports" ||
+        this.categoryName == "David Kato College Sports" ||
         this.categoryName == "Hes East College Sports"
       ) {
         this.firstSegmentName = "College Sport";
@@ -133,10 +134,10 @@ export default {
         this.secondSegmentUrl = "/activities/view/halifax-sport";
       } else if (this.categoryName == "Langwith College Sports") {
         this.secondSegmentUrl = "/activities/view/langwith-sport";
-      } else if (
-        this.categoryName == "Anne Lister & David Kato College Sports"
-      ) {
-        this.secondSegmentUrl = "/activities/view/lister_kato_sport";
+      } else if (this.categoryName == "Anne Lister College Sports") {
+        this.secondSegmentUrl = "/activities/view/lister_sport";
+      } else if (this.categoryName == "David Kato College Sports") {
+        this.secondSegmentUrl = "/activities/view/davidkatosport";
       }
 
       if (this.secondSegmentUrl) {

--- a/src/components/activity-page/activity-page.ce.vue
+++ b/src/components/activity-page/activity-page.ce.vue
@@ -220,10 +220,13 @@ export default {
         this.subgroupCategoryName = "Halifax College Sports";
       } else if (this.groupId == "553") {
         this.subgroupCategoryId = 38;
-        this.subgroupCategoryName = "Anne Lister & David Kato College Sports";
+        this.subgroupCategoryName = "Anne Lister College Sports";
       } else if (this.groupId == "398") {
         this.subgroupCategoryId = "37,45";
         this.subgroupCategoryName = "Langwith College Sports";
+      } else if (this.groupId == "763") {
+        this.subgroupCategoryId = 46;
+        this.subgroupCategoryName = "David Kato College Sports";
       }
     },
   },

--- a/src/components/group-page/group-page.ce.vue
+++ b/src/components/group-page/group-page.ce.vue
@@ -183,10 +183,13 @@ export default {
         this.subgroupCategoryName = "Halifax College Sports";
       } else if (this.groupId == "553") {
         this.subgroupCategoryId = 38;
-        this.subgroupCategoryName = "Anne Lister & David Kato College Sports";
+        this.subgroupCategoryName = "Anne Lister College Sports";
       } else if (this.groupId == "398") {
         this.subgroupCategoryId = "37,45";
         this.subgroupCategoryName = "Langwith College Sports";
+      } else if (this.groupId == "763") {
+        this.subgroupCategoryId = 46;
+        this.subgroupCategoryName = "David Kato College Sports";
       }
     },
   },

--- a/src/pages/student-life/activities-view/activities-view.stories.js
+++ b/src/pages/student-life/activities-view/activities-view.stories.js
@@ -93,6 +93,28 @@ export const ConstantineSport = {
   },
 };
 
+export const DavidKatoSport = {
+  args: {
+    activityid: 763,
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};
+
+export const ListerSport = {
+  args: {
+    activityid: 553,
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because it's user submitted content and will always fail.
+    },
+  },
+};
+
 export const SwapShop = {
   args: {
     activityid: 382,


### PR DESCRIPTION
### Description

This pull request updates the handling of college sports categories throughout the codebase to separate "Anne Lister & David Kato College Sports" into two distinct categories: "Anne Lister College Sports" and "David Kato College Sports." The changes ensure that navigation, display, and storybook stories correctly reflect this split.

**College Sports Category Split:**

* Updated logic in `activity-breadcrumb.ce.vue` to recognize "Anne Lister College Sports" and "David Kato College Sports" as separate categories, replacing the previous combined category.
* Adjusted URL routing in `activity-breadcrumb.ce.vue` so each new category points to its own specific activity view URL.

**Group and Activity Page Updates:**

* Modified group and activity page logic in `activity-page.ce.vue` and `group-page.ce.vue` to assign the correct subgroup category names and IDs for the newly separated sports categories. [[1]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623L223-R229) [[2]](diffhunk://#diff-9cea4c2c49529ef04e27f00e71e2253820f475609ef5f7715ef7c6bb8c6d0e3dL186-R192)

**Storybook Additions:**

* Added new stories for "David Kato College Sports" and "Anne Lister College Sports" in `activities-view.stories.js` to support testing and documentation of each category independently.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
