### PR TITLE
Updated advice A-Z functionality

### DIFF
--- a/src/components/advice-a-z/advice-a-z.ce.vue
+++ b/src/components/advice-a-z/advice-a-z.ce.vue
@@ -143,6 +143,16 @@ export default {
     },
     updateCategory: function (category) {
       this.selectedCategory = category;
+      if (this.Search) {
+        this.Search = "";
+      }
+    },
+  },
+  watch: {
+    Search: function (newVal, oldVal) {
+      if (newVal && !oldVal && this.selectedCategory) {
+        this.selectedCategory = "";
+      }
     },
   },
   computed: {


### PR DESCRIPTION
### Description

This pull request introduces improvements to the category selection and search input behavior in the `advice-a-z.ce.vue` component. The main focus is on ensuring that selecting a category resets the search input, and entering a search term clears any selected category for a smoother user experience.

Category and search interaction improvements:

* When a category is selected using `updateCategory`, the `Search` input is now reset to an empty string if it previously had a value.
* A new watcher on `Search` clears the selected category whenever a search term is entered, ensuring that only one filter is active at a time.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
