### PR TITLE
Fixed 404 error when dragging carousel on desktop

### DIFF
--- a/src/components/Carousel/carousel.ce.vue
+++ b/src/components/Carousel/carousel.ce.vue
@@ -9,7 +9,8 @@
         aria-label="Homepage carousel"
         :autoplay="autoplayEnabled"
         :duration="interval * 1000"
-        :touchable="true"
+        :touchable="false"
+        :breakpoints="carouselBreakpoints"
         :bullets="false"
         :arrows="false"
         :pause-on-hover="false"
@@ -98,6 +99,11 @@ export default {
       banners: [],
       slidesKey: 0,
       currentSlideIndex: 0,
+      carouselBreakpoints: {
+        767: {
+          touchable: true,
+        },
+      },
     };
   },
   async created() {


### PR DESCRIPTION
### Description

This pull request updates the behavior of the homepage carousel component to improve its touch interaction and responsiveness. The main change is to disable touch interactions by default, but enable them for screens smaller than 767px using breakpoints.

**Carousel touch interaction and responsiveness:**

* Disabled the `touchable` property by default on the carousel, but added a `carouselBreakpoints` configuration to enable touch support for devices with a screen width of 767px or less. (`src/components/Carousel/carousel.ce.vue`) [[1]](diffhunk://#diff-ee44ff57004794fcb124a5d6d0fb9b2c61385457344be33d7004a7c51361d895L12-R13) [[2]](diffhunk://#diff-ee44ff57004794fcb124a5d6d0fb9b2c61385457344be33d7004a7c51361d895R102-R106)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
