### PR TITLE
Added clarity cookie consent

### DIFF
--- a/src/components/cookie-consent/cookie-consent.ce.vue
+++ b/src/components/cookie-consent/cookie-consent.ce.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    id="error-modal"
+    id="cookie-consent"
     class="align-end fixed bottom-0 left-0 z-50 flex justify-start overflow-x-hidden overflow-y-auto"
     aria-label="Cookie Consent Modal"
     role="dialog"
@@ -16,8 +16,9 @@
             <p>
               We use necessary cookies to ensure you get the best experience on
               our website. By continuing on our site you are agreeing to using
-              cookies to help us understand usage and how to improve it. View
-              our
+              cookies to help us understand usage and how to improve it, you can
+              help us further by accepting optional cookies which allows us
+              further insights into your experience on our site. View our
               <a
                 href="/documents/cookie-policy"
                 class="text-blue-800 underline dark:text-blue-400"
@@ -27,14 +28,21 @@
           </div>
         </div>
         <div
-          class="flex items-center justify-items-end gap-3 rounded-b-sm border-t border-gray-200 p-4 md:p-5 dark:border-gray-600"
+          class="flex flex-wrap items-center justify-items-end gap-3 rounded-b-sm border-t border-gray-200 p-4 md:p-5 dark:border-gray-600"
         >
+          <button
+            type="button"
+            class="btn btn-primary"
+            @click="rejectCookies()"
+          >
+            Accept Required Cookies
+          </button>
           <button
             type="button"
             class="btn btn-primary"
             @click="acceptCookies()"
           >
-            Close
+            Accept all Cookies
           </button>
         </div>
       </div>
@@ -55,7 +63,7 @@ export default {
   },
   mounted() {
     const cookieConsent = getCookie("yorksu-cookie-consent");
-    if (cookieConsent === "ok") {
+    if (cookieConsent === "ok" || cookieConsent === "rejected") {
       this.displayCookieConsent = false;
     }
   },
@@ -64,13 +72,21 @@ export default {
       setCookie("yorksu-cookie-consent", "ok", {
         expires: 365,
       });
+      window.clarity("consentv2", {
+        ad_storage: "granted",
+        analytics_storage: "granted",
+      });
       this.displayCookieConsent = false;
     },
     rejectCookies() {
       setCookie("yorksu-cookie-consent", "rejected", {
-        expires: 365,
+        expires: 3,
       });
-      this.displayCookieConsent = true;
+      window.clarity("consentv2", {
+        ad_storage: "denied",
+        analytics_storage: "denied",
+      });
+      this.displayCookieConsent = false;
     },
   },
 };


### PR DESCRIPTION
### Description

This pull request updates the cookie consent modal to provide more granular options for users and improves consent handling logic. The main changes include adding a separate button for accepting only required cookies, updating the consent messaging, and integrating with the Clarity analytics consent API.

**User Experience Improvements:**

* Added a new button labeled "Accept Required Cookies" (`rejectCookies()`), allowing users to reject optional cookies but accept necessary ones. The modal now clearly distinguishes between accepting all cookies and only the required ones.
* Updated the consent message to explain the difference between required and optional cookies, making it clearer for users what each option means.

**Consent Logic and Analytics Integration:**

* When a user accepts all cookies, the code now explicitly grants ad and analytics storage consent via the Clarity API (`window.clarity("consentv2", ...)`).
* When a user accepts only required cookies, the code denies ad and analytics storage consent via the Clarity API, and sets the consent cookie to expire in 3 days instead of 365.
* Updated the modal logic to hide the consent banner if the consent cookie is set to either "ok" or "rejected", ensuring users are not repeatedly prompted.

**Accessibility and Semantics:**

* Changed the modal's `id` from `error-modal` to `cookie-consent` for improved semantic clarity.
* Modified the modal footer to use `flex-wrap` for better layout on smaller screens.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
