### PR TITLE
Tweaked cookie name and parameters

### DIFF
--- a/src/components/cookie-consent/cookie-consent.ce.vue
+++ b/src/components/cookie-consent/cookie-consent.ce.vue
@@ -62,7 +62,7 @@ export default {
     };
   },
   mounted() {
-    const cookieConsent = getCookie("yorksu-cookie-consent");
+    const cookieConsent = getCookie("yorksu-clarity-cookie-consent");
     if (cookieConsent === "ok" || cookieConsent === "rejected") {
       this.displayCookieConsent = false;
     }


### PR DESCRIPTION
### Description

This pull request updates the cookie consent logic to align with new naming conventions and corrects the keys used for consent signaling to the `clarity` service.

**Cookie consent logic updates:**

* Changed the cookie name from `yorksu-cookie-consent` to `yorksu-clarity-cookie-consent` in both the `acceptCookies` and `rejectCookies` methods to match the new standard.

**Consent signaling fixes:**

* Updated the consent object keys passed to `window.clarity("consentv2", ...)` from `ad_storage` and `analytics_storage` to `ad_Storage` and `analytics_Storage` for both acceptance and rejection flows, ensuring proper integration with the clarity service.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
