### PR TITLE
Adds stall maps to welcome fair locations

### DIFF
--- a/src/_common/stallMaps.mjs
+++ b/src/_common/stallMaps.mjs
@@ -1,0 +1,30 @@
+export const stallMaps = [
+  {
+    id: "1",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/sports-centre-arena.pdf",
+  },
+  {
+    id: "2",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/sports-centre-main-hall.pdf",
+  },
+  {
+    id: "3",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/physics.pdf",
+  },
+  {
+    id: "4",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/central-hall.pdf",
+  },
+  {
+    id: "5",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/spring-lane-building.pdf",
+  },
+  {
+    id: "7",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/vanbrugh-dining-hall.pdf",
+  },
+  {
+    id: "8",
+    map: "https://assets-cdn.sums.su/YU/website/img/Welcome-Fair/roger-kirk-centre.pdf",
+  },
+];

--- a/src/components/welcome-fair/welcome-fair-index/welcome-fair.ce.vue
+++ b/src/components/welcome-fair/welcome-fair-index/welcome-fair.ce.vue
@@ -25,6 +25,20 @@
           :class="{ '!btn-primary-active': locationFilter === location.id }"
         />
       </div>
+      <div v-if="locationFilter" class="flex flex-wrap gap-4">
+        <Button
+          title="See on map"
+          is-secondary
+          :url="'https://yorksu.org/map?location=' + locationFilter"
+        />
+        <Button
+          v-if="currentStallMap"
+          title="Stalls Map"
+          is-secondary
+          :url="currentStallMap.map"
+          target="_blank"
+        />
+      </div>
     </div>
     <div class="a-z-wrap" v-if="stalls.length > 0 && !loading">
       <div
@@ -114,6 +128,7 @@
 import axios from "../../../_common/axios.mjs";
 import Button from "../../button/button.ce.vue";
 import { randomImageUrl } from "../../../_common/randomImage.mjs";
+import { stallMaps } from "../../../_common/stallMaps.mjs";
 import InterestButton from "../../interest-button/interest-button.ce.vue";
 import Pagination from "../../Pagination/pagination.ce.vue";
 import Tile from "../../Tile/tile.ce.vue";
@@ -139,6 +154,7 @@ export default {
       PreviousResults: false,
       loading: false,
       search: "",
+      stallMaps,
     };
   },
   mounted() {
@@ -238,6 +254,9 @@ export default {
     },
     getImg() {
       return randomImageUrl("student-life");
+    },
+    currentStallMap() {
+      return this.stallMaps.find((stall) => stall.id === this.locationFilter);
     },
   },
 };

--- a/src/components/welcome-fair/welcome-map/welcome-map.ce.vue
+++ b/src/components/welcome-fair/welcome-map/welcome-map.ce.vue
@@ -21,6 +21,7 @@
 <script>
 import mapboxgl from "https://cdn.jsdelivr.net/npm/mapbox-gl@3.6.0/+esm";
 import axios from "../../../_common/axios.mjs";
+import { stallMaps } from "../../../_common/stallMaps.mjs";
 import Modal from "../../modal/modal.ce.vue";
 export default {
   name: "WelcomeMap",
@@ -36,6 +37,7 @@ export default {
       urlLocation: "",
       activeLocation: {},
       ModalClosed: true,
+      stallMaps,
     };
   },
   mounted() {
@@ -222,6 +224,17 @@ export default {
         seeStallsButton.textContent = "See Stalls";
         seeStallsButton.href = `/welcome-fair?location=${features.properties.id}`;
         popupContent.appendChild(seeStallsButton);
+
+        const stallMap = this.stallMaps.find(
+          (stall) => stall.id === features.properties.id,
+        );
+        if (stallMap) {
+          const seeStallsMap = seeStallsButton.cloneNode(true);
+          seeStallsMap.textContent = "Stalls Map";
+          seeStallsMap.href = stallMap.map;
+          seeStallsMap.target = "_blank";
+          popupContent.appendChild(seeStallsMap);
+        }
       }
 
       const directionsButton = document.createElement("button");


### PR DESCRIPTION
### Description

This pull request adds support for displaying stall maps for different locations at the Welcome Fair. The main changes introduce a new data source for stall maps and update both the index and map components to show links to these maps when a location is selected.

**Stall map integration:**

* Added a new `stallMaps` array in `src/_common/stallMaps.mjs` containing mapping between location IDs and their corresponding PDF map URLs.
* Imported and made `stallMaps` available in both `welcome-fair-index` and `welcome-map` components, allowing access to stall map data. [[1]](diffhunk://#diff-25290b3964a208e6baa5a5566c0b82f136d40123ff30067674d8b0516c0c976eR131) [[2]](diffhunk://#diff-e452d62a8235dc0e2cfd3e41596cac89fcdb8b220ead7b0b2176d5da500e7130R24) [[3]](diffhunk://#diff-25290b3964a208e6baa5a5566c0b82f136d40123ff30067674d8b0516c0c976eR157) [[4]](diffhunk://#diff-e452d62a8235dc0e2cfd3e41596cac89fcdb8b220ead7b0b2176d5da500e7130R40)

**UI enhancements for map links:**

* In `welcome-fair-index`, added a "Stalls Map" button that appears when a location is selected, linking to the relevant stall map PDF in a new tab. [[1]](diffhunk://#diff-25290b3964a208e6baa5a5566c0b82f136d40123ff30067674d8b0516c0c976eR28-R41) [[2]](diffhunk://#diff-25290b3964a208e6baa5a5566c0b82f136d40123ff30067674d8b0516c0c976eR258-R260)
* In `welcome-map`, updated the popup to include a "Stalls Map" link for locations with an associated map, also opening in a new tab.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
