### PR TITLE
Added dynamic menu component to Venues

### DIFF
--- a/src/components/venue-menu/venue-menu.ce.vue
+++ b/src/components/venue-menu/venue-menu.ce.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="py-10">
+    <button
+      class="btn-primary rounded p-4 transition-[width] duration-1000 ease-in-out"
+      :class="menuOpen ? 'w-full rounded-b-none' : 'w-48'"
+      @click="menuOpen = !menuOpen"
+    >
+      {{ title }} menu
+    </button>
+    <div
+      class="overflow-hidden rounded-b border bg-[#f7f7f7] transition-all duration-1000 ease-in-out"
+      :class="
+        menuOpen
+          ? 'max-h-[100vh] w-full'
+          : 'aria-hidden max-h-0 w-48 border-none'
+      "
+    >
+      <iframe
+        v-if="menu"
+        :src="pdfUrl"
+        class="aspect-[4/5] max-h-[90vh] min-h-[50vh] w-full"
+        :aria-label="`${title} menu`"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "VenueMenu",
+  props: {
+    title: {
+      type: String,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      menus: [
+        {
+          title: "The Courtyard",
+          menu: "https://assets-cdn.sums.su/YU/Evening_Menu_Online.pdf",
+        },
+      ],
+      menuOpen: false,
+    };
+  },
+  computed: {
+    menu() {
+      const menu = this.menus.find((m) => m.title === this.title);
+      return menu ? menu.menu : null;
+    },
+    pdfUrl() {
+      if (!this.menu) return null;
+      return `${this.menu}#view=FitH&zoom=page-width`;
+    },
+  },
+};
+</script>

--- a/src/components/venue-menu/venue-menu.component.js
+++ b/src/components/venue-menu/venue-menu.component.js
@@ -1,0 +1,4 @@
+import { register } from "../../_common/registerComponent";
+import VenueMenu from "./venue-menu.ce.vue";
+
+register("venue-menu", VenueMenu);

--- a/src/components/venue-menu/venue-menu.stories.js
+++ b/src/components/venue-menu/venue-menu.stories.js
@@ -1,0 +1,12 @@
+import "./venue-menu.component.js";
+
+export default {
+  title: "Components/Venue Menu",
+  component: "venue-menu",
+};
+
+export const Default = {
+  args: {
+    title: "The Courtyard",
+  },
+};

--- a/src/components/venue-page/venue-page.ce.vue
+++ b/src/components/venue-page/venue-page.ce.vue
@@ -5,12 +5,14 @@
   <main>
     <article v-html="page_content"></article>
   </main>
+  <VenueMenu :title="title" />
   <Events :venueid="page_class" title="Events" icon class="" />
   <article v-html="additional_page_content"></article>
 </template>
 <!-- eslint-disable vue/prop-name-casing -->
 <script>
 import Events from "../../components/Events/events.ce.vue";
+import VenueMenu from "../../components/venue-menu/venue-menu.ce.vue";
 
 export default {
   name: "VenuePage",
@@ -38,6 +40,7 @@ export default {
   },
   components: {
     Events,
+    VenueMenu,
   },
 };
 </script>

--- a/src/components/venue-page/venue-page.stories.js
+++ b/src/components/venue-page/venue-page.stories.js
@@ -11,7 +11,7 @@ export const Default = {
 
 export const Courtyard = {
   args: {
-    title: "Courtyard",
+    title: "The Courtyard",
     page_content: `<p>Whether you&#39;re just looking for a daytime coffee or wanting to watch some live sports on an evening, The Courtyard is the place to be! With a range of events from quizzes to karaoke, a beer garden, and a variety of food to satisfy your taste buds, you can always find what you need at The Courtyard.</p><hr /><h2>Opening hours</h2><p>Monday - Friday 8:30-23:00</p><p>Saturday - Sunday 11:00-23:00</p><hr /><h2>Order to table</h2><p>You can now order food and drink directly to your table in Courtyard!</p><!-- <p><a href="https://order.storekit.com/yusu-courtyard/menu">Use this link to get started!</a></p> --><p>Snap the QR code on your table to get started or <a href="https://order.storekit.com/yusu-courtyard/menu">click here to open our ordering portal.</a></p><hr /><h2>Food and drink</h2><p>We have a range of food and drinks on offer, so why not pop in and take a look?</p><ul><li><a href="https://assets-cdn.sums.su/YU/Venues/Weirdough_Menu.pdf" target="_blank">WeirDough menu</a></li></ul>`,
     page_class: "1",
     page_key_image:

--- a/src/pages/venues/venues.stories.js
+++ b/src/pages/venues/venues.stories.js
@@ -11,7 +11,7 @@ export const Default = {
 
 export const Courtyard = {
   args: {
-    title: "Courtyard",
+    title: "The Courtyard",
     page_content: `<p>Whether you&#39;re just looking for a daytime coffee or wanting to watch some live sports on an evening, The Courtyard is the place to be! With a range of events from quizzes to karaoke, a beer garden, and a variety of food to satisfy your taste buds, you can always find what you need at The Courtyard.</p><hr /><h2>Opening hours</h2><p>Monday - Friday 8:30-23:00</p><p>Saturday - Sunday 11:00-23:00</p><hr /><h2>Order to table</h2><p>You can now order food and drink directly to your table in Courtyard!</p><!-- <p><a href="https://order.storekit.com/yusu-courtyard/menu">Use this link to get started!</a></p> --><p>Snap the QR code on your table to get started or <a href="https://order.storekit.com/yusu-courtyard/menu">click here to open our ordering portal.</a></p><hr /><h2>Food and drink</h2><p>We have a range of food and drinks on offer, so why not pop in and take a look?</p><ul><li><a href="https://assets-cdn.sums.su/YU/Venues/Weirdough_Menu.pdf" target="_blank">WeirDough menu</a></li></ul>`,
     page_class: "1",
     page_key_image:


### PR DESCRIPTION
### Description

This pull request introduces a new `VenueMenu` component that displays a venue's menu in an expandable section, and integrates it into the venue page. It also updates related stories to ensure consistency in venue naming and demonstrates the new component in Storybook.

**New Venue Menu Feature:**

* Added a new `VenueMenu` component (`venue-menu.ce.vue`) that displays a button to toggle showing a venue's menu PDF in an iframe, with smooth transitions and accessibility improvements.
* Registered the new component as a custom element for use in the app (`venue-menu.component.js`).
* Added a Storybook story for the new `VenueMenu` component to facilitate testing and documentation (`venue-menu.stories.js`).

**Integration with Venue Page:**

* Integrated the `VenueMenu` component into the `VenuePage` component so that each venue page can display its menu. [[1]](diffhunk://#diff-406e3e92238e61a74e472feb501732bd2802b91bb3acfb1faaf9512952400accR8-R15) [[2]](diffhunk://#diff-406e3e92238e61a74e472feb501732bd2802b91bb3acfb1faaf9512952400accR43)

**Story and Naming Consistency:**

* Updated the `title` prop for "The Courtyard" in both `venue-page.stories.js` and `venues.stories.js` to ensure the new menu appears for the correct venue. [[1]](diffhunk://#diff-4b23971c8f17eb9f843bf597611455d0c4299085a9b1513b022f5ac9de75d46aL14-R14) [[2]](diffhunk://#diff-fc783fbf7e872400c4e49866bb9effb16b7b893b875e72449f3c0207ef2e98bdL14-R14)

### Checklist

- [ ] I accept the contributor license agreement for this repository.
- [ ] All active GitHub checks for tests, formatting, and security are passing.
- [ ] The correct base branch is being used (if not `main`).
- [ ] A GitHub issue or linear task is linked to this pull request.
