### PR TITLE
Added documents to activity pages

### DIFF
--- a/src/components/activity-page/activity-page.ce.vue
+++ b/src/components/activity-page/activity-page.ce.vue
@@ -182,18 +182,9 @@ export default {
             "X-Site-Id": self.siteid,
           },
         }),
-        axios.get("https://yorksu.org/activities/badges-api/" + self.groupId, {
-          headers: {
-            "X-Site-Id": self.siteid,
-          },
-        }),
+        axios.get("https://yorksu.org/activities/badges-api/" + self.groupId),
         axios.get(
           "https://yorksu.org/activities/documents-api/" + self.groupId,
-          {
-            headers: {
-              "X-Site-Id": self.siteid,
-            },
-          },
         ),
       ])
       .then(


### PR DESCRIPTION
### Description

This pull request adds support for displaying related documents on the activity page. The main changes include fetching documents from a new API endpoint, storing them in component state, and rendering a new "Documents" section if any documents are available.

**Documents feature:**

* Added a new API call to fetch documents related to the activity using the `/activities/documents-api/` endpoint, and store the results in the `documents` array in component state. [[1]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R190-R200) [[2]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R158) [[3]](diffhunk://#diff-e870a6fe4dbbe68cff52c5fb2a08b0c6a497e66e2bcb6543173115b052e62623R214-R216)
* Added a new "Documents" section to the activity page UI, which displays a list of document links if any documents are present.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
