### PR TITLE
Fixed pdf menu scaling and scrolling

### DIFF
--- a/src/components/venue-menu/venue-menu.ce.vue
+++ b/src/components/venue-menu/venue-menu.ce.vue
@@ -29,6 +29,8 @@
           class="aspect-[4/5] max-h-[90vh] min-h-[50vh] w-full"
           :aria-label="`${menuItem.displayName} menu`"
           :tabindex="openMenus[index] ? '0' : '-1'"
+          allow="fullscreen"
+          scrolling="yes"
         />
       </div>
     </div>
@@ -90,7 +92,7 @@ export default {
     },
     getPdfUrl(menuUrl) {
       if (!menuUrl) return null;
-      return `${menuUrl}#view=FitH&zoom=page-width`;
+      return `https://drive.google.com/viewerng/viewer?embedded=true&url=${menuUrl}#view=FitH&zoom=page-width`;
     },
     getMenuContentId(index) {
       return `menu-content-${this.title?.toLowerCase().replace(/\s+/g, "-") || "default"}-${index}`;


### PR DESCRIPTION
### Description

This pull request updates the `venue-menu.ce.vue` component to improve how PDF menus are displayed within the venue menu. The main changes focus on enhancing PDF embedding and accessibility.

**PDF Embedding Improvements**
* The `getPdfUrl` method now uses the Google Drive PDF viewer to embed PDFs, which offers better compatibility and viewing experience for users. (`src/components/venue-menu/venue-menu.ce.vue`)

**Accessibility and Viewer Enhancements**
* The embedded PDF `<iframe>` now includes the `allow="fullscreen"` and `scrolling="yes"` attributes, enabling users to view the menu in fullscreen and scroll through the content more easily. (`src/components/venue-menu/venue-menu.ce.vue`)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
