### PR TITLE
Related News Patch

### DIFF
--- a/src/components/view-news/view-news.ce.vue
+++ b/src/components/view-news/view-news.ce.vue
@@ -27,7 +27,7 @@
       class="body-style mb-5"
     ></article>
     <Loading :loading="loading" text></Loading>
-    <div class="flex flex-col gap-4 pt-10" v-if="categories.length">
+    <div class="flex flex-col gap-4 pt-10" v-if="categories">
       <h2 class="text-3xl font-bold">Related News</h2>
       <News :selected-categories="categories" embedded />
     </div>
@@ -66,8 +66,18 @@ export default {
       articleAge: "",
       loading: true,
       image: "",
-      categories: [],
+      categories: "",
     };
+  },
+  watch: {
+    categoryName: {
+      handler(newValue) {
+        if (newValue) {
+          this.getArticleCategories();
+        }
+      },
+      immediate: true,
+    },
   },
   methods: {
     randomImage() {
@@ -92,6 +102,10 @@ export default {
       }
     },
     async getArticleCategories() {
+      if (!this.categoryName) {
+        return;
+      }
+
       let name = this.categoryName
         .split("|")
         .map((cat) => cat.trim())
@@ -122,9 +136,6 @@ export default {
           self.image = self.Article.thumbnail;
         }
         self.articleAge = self.getArticleAge(self.Article.date);
-        if (self.categoryName) {
-          self.getArticleCategories();
-        }
         self.loading = false;
       })
       .catch(function () {

--- a/src/components/view-news/view.stories.js
+++ b/src/components/view-news/view.stories.js
@@ -26,6 +26,6 @@ export const OldArticle = {
 export const WithCategories = {
   args: {
     articleid: "2266",
-    categoryName: "Student Life|Freshers| ",
+    categoryName: "Student Life|Freshers|",
   },
 };


### PR DESCRIPTION
### Description

This pull request refactors how article categories are handled in the `view-news.ce.vue` component. The main improvement is switching from an array to a string for the `categories` data property, and using a Vue watcher to automatically fetch related categories when `categoryName` changes. This makes the component more reactive and simplifies category management.

**Category handling improvements:**

* Changed the `categories` data property from an array to a string, and updated the conditional rendering logic to check if `categories` exists rather than its length. (`src/components/view-news/view-news.ce.vue`) [[1]](diffhunk://#diff-e372af1c98c2df6eb7da51dbdef43683aea5257539624a3ca38b832bc3ef6c16L30-R30) [[2]](diffhunk://#diff-e372af1c98c2df6eb7da51dbdef43683aea5257539624a3ca38b832bc3ef6c16L69-R81)
* Added a Vue watcher on `categoryName` to automatically call `getArticleCategories` whenever `categoryName` changes, ensuring related news is always updated when the category changes. (`src/components/view-news/view-news.ce.vue`)
* Removed the previous manual call to `getArticleCategories` from the article loading logic, since the watcher now handles this automatically. (`src/components/view-news/view-news.ce.vue`)
* Added a guard clause in `getArticleCategories` to prevent unnecessary processing if `categoryName` is not set. (`src/components/view-news/view-news.ce.vue`)

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
