### PR TITLE
Elections Referendum Handling

### DIFF
--- a/src/components/elections-vote/elections-vote.stories.js
+++ b/src/components/elections-vote/elections-vote.stories.js
@@ -15,3 +15,14 @@ export const Default = {
     },
   },
 };
+
+export const Referendum = {
+  args: {
+    electionId: "2326",
+  },
+  parameters: {
+    a11y: {
+      disable: true, // Disables the a11y check for this specific story, because of an accessibility issue we are looking in to. [WEB-459]
+    },
+  },
+};


### PR DESCRIPTION
### Description

This pull request updates the `elections-vote` component to support referendum-style elections in addition to the existing STV system. It introduces conditional rendering and logic to handle voting, display, and submission for referendums, ensuring users can only select one option and see appropriate instructions and UI labels.

**Referendum voting and UI support:**

* Added conditional instructions and UI elements for referendums, including a new list item explaining single-choice voting and updating section headers to display "Options" instead of "Candidates" when the election method is `REFERENDUM`. [[1]](diffhunk://#diff-5c4ddb3679dc8a0c4300be2fcc731ff3d9bf49a62f0d0ed839cd734bbb493d55R29-R32) [[2]](diffhunk://#diff-5c4ddb3679dc8a0c4300be2fcc731ff3d9bf49a62f0d0ed839cd734bbb493d55L46-R55)
* Implemented conditional rendering for candidate/option cards, showing only the name for referendum options and hiding STV-specific UI elements. [[1]](diffhunk://#diff-5c4ddb3679dc8a0c4300be2fcc731ff3d9bf49a62f0d0ed839cd734bbb493d55R69) [[2]](diffhunk://#diff-5c4ddb3679dc8a0c4300be2fcc731ff3d9bf49a62f0d0ed839cd734bbb493d55R126-R135)

**Referendum voting logic:**

* Modified vote selection logic to allow only one option to be selected in a referendum, resetting previous selections and updating state accordingly.
* Updated form submission logic to handle referendums, submitting the selected option under the correct form field.

**Storybook support:**

* Added a new Storybook story for referendum elections with accessibility checks disabled for further investigation.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
