### PR TITLE
Abstracted expanding button component

### DIFF
--- a/src/components/expanding-button/expanding-button.ce.vue
+++ b/src/components/expanding-button/expanding-button.ce.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="expanding-button-container">
+    <button
+      :id="buttonId"
+      class="btn-primary rounded p-4 transition-[width] duration-500 ease-in-out"
+      :class="isExpanded ? 'w-full rounded-b-none' : collapsedWidth"
+      @click="toggleExpanded"
+      :aria-expanded="isExpanded"
+      :aria-controls="contentId"
+      :aria-label="`${isExpanded ? 'Close' : 'Open'} ${buttonTitle}`"
+      type="button"
+    >
+      <slot name="button" :is-expanded="isExpanded">
+        {{ buttonTitle }}
+      </slot>
+    </button>
+    <div
+      :id="contentId"
+      class="rounded-b border bg-white transition-all duration-500 ease-in-out"
+      :class="
+        isExpanded
+          ? 'max-h-[100vh] w-full overflow-x-auto p-6'
+          : `max-h-0 overflow-hidden border-none ${collapsedWidth}`
+      "
+      :aria-hidden="!isExpanded"
+      :aria-labelledby="buttonId"
+    >
+      <slot :is-expanded="isExpanded" :toggle-expanded="toggleExpanded"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ExpandingButton",
+  props: {
+    buttonTitle: {
+      type: String,
+      default: "Toggle Content",
+    },
+    buttonId: {
+      type: String,
+      default: "expanding-button",
+    },
+    contentId: {
+      type: String,
+      default: "expanding-content",
+    },
+    collapsedWidth: {
+      type: String,
+      default: "w-48",
+    },
+    initiallyExpanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["toggle", "expanded", "collapsed"],
+  data() {
+    return {
+      isExpanded: this.initiallyExpanded,
+    };
+  },
+  methods: {
+    toggleExpanded() {
+      this.isExpanded = !this.isExpanded;
+      this.$emit("toggle", this.isExpanded);
+      this.$emit(this.isExpanded ? "expanded" : "collapsed");
+    },
+  },
+};
+</script>

--- a/src/components/expanding-button/expanding-button.component.js
+++ b/src/components/expanding-button/expanding-button.component.js
@@ -1,0 +1,4 @@
+import { register } from "../../_common/registerComponent";
+import ExpandingButton from "./expanding-button.ce.vue";
+
+register("expanding-button", ExpandingButton);

--- a/src/components/expanding-button/expanding-button.stories.js
+++ b/src/components/expanding-button/expanding-button.stories.js
@@ -1,0 +1,8 @@
+import "./expanding-button.component.js";
+
+export default {
+  title: "Components/Expanding Button",
+  component: "expanding-button",
+};
+
+export const Default = {};

--- a/src/pages/social-sport-page/social-sport-page.ce.vue
+++ b/src/pages/social-sport-page/social-sport-page.ce.vue
@@ -4,7 +4,16 @@
     title="Social Sport"
   />
   <div class="container mx-auto">
-    <EventTimetable :button-title="'Social Sport Timetable'" :type-id="30" />
+    <expanding-button
+      button-title="Social Sport Timetable"
+      button-id="social-sport-timetable-button"
+      content-id="social-sport-timetable-content"
+      collapsed-width="w-48"
+    >
+      <template #default="{ isExpanded }">
+        <EventTimetable :type-id="30" :is-visible="isExpanded" />
+      </template>
+    </expanding-button>
   </div>
   <div id="main" class="body-style container mx-auto">
     <!-- Main Content -->
@@ -58,6 +67,7 @@ import HeroHeader from "../../components/HeroHeader/heroheader.ce.vue";
 import Footer from "../../components/Footer/footer.ce.vue";
 import Events from "../../components/Events/events.ce.vue";
 import EventTimetable from "../../components/event-timetable/event-timetable.ce.vue";
+import ExpandingButton from "../../components/expanding-button/expanding-button.ce.vue";
 export default {
   name: "SocialSportPage",
   components: {
@@ -65,6 +75,7 @@ export default {
     Footer,
     Events,
     EventTimetable,
+    ExpandingButton,
   },
 };
 </script>


### PR DESCRIPTION
### Description

This pull request refactors the timetable expansion logic by introducing a new reusable `ExpandingButton` component and updating the `EventTimetable` component to work with it. This change improves code modularity and accessibility, making the timetable expansion more flexible and easier to maintain.

**Component Refactoring and Reusability:**

* Added a new `ExpandingButton` component (`expanding-button.ce.vue`) that encapsulates the expand/collapse button and its associated content, with proper accessibility attributes and slot support for custom content.
* Registered the new `ExpandingButton` component and added a Storybook story for documentation and testing. [[1]](diffhunk://#diff-babe40c24a1df50bee83be2c74462ff4cdd9a4d775b3b05167ffb761de2584e2R1-R4) [[2]](diffhunk://#diff-8a79ad5cce30c18b909a472490adc7473f52df9e4d95b8a5acdb27b9b27c5c6aR1-R8)

**Integration and API Changes:**

* Refactored the `SocialSportPage` to use the new `ExpandingButton` for the timetable, passing the expanded state to `EventTimetable` via the `is-visible` prop. [[1]](diffhunk://#diff-323d85fae48879fc050a1b12f7b668fb25057c3247a2eda5e21f5f7e2c1a6645L7-R16) [[2]](diffhunk://#diff-323d85fae48879fc050a1b12f7b668fb25057c3247a2eda5e21f5f7e2c1a6645R70-R78)
* Updated the `EventTimetable` component to remove its own expand/collapse button and related logic, and replaced the `isExpanded` state and prop with `isVisible`, which is now controlled by the parent component. All relevant tabindex bindings now use `isVisible` instead of `isExpanded`. [[1]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L3-R8) [[2]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L43-R19) [[3]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L52-R28) [[4]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L86-R62) [[5]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L112-L113) [[6]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L129-R110) [[7]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L153) [[8]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L264-L270)

**Behavior and Accessibility Improvements:**

* Ensured that the timetable content and interactive elements are only accessible when visible, improving keyboard navigation and accessibility. [[1]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L3-R8) [[2]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L43-R19) [[3]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L52-R28) [[4]](diffhunk://#diff-4d7610bcf0205e20c4968a46ca363381d33ea9c80b0f9158de93ada202c02252L86-R62)
* The timetable now fetches events on mount rather than on expand, ensuring data is loaded promptly.

### Checklist

- [x] I accept the contributor license agreement for this repository.
- [x] All active GitHub checks for tests, formatting, and security are passing.
- [x] The correct base branch is being used (if not `main`).
- [x] A GitHub issue or linear task is linked to this pull request.
